### PR TITLE
【確認待ち】ライブラリとして使えるように調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ composer require vektor-inc/vk-term-color
 ```
 use VektorInc\VK_Term_Color\VkTermColor;
 
+// カラーピッカー使用時のみ
+$vk_term_color = VkTermColor::get_instance();
+$vk_term_color->init( 'text_domain' ); 
+
+
+// 表示用のHTMLを取得する
 $args = array(
 	'outer_element'      => 'div',
 	'outer_class'        => '',

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ use VektorInc\VK_Term_Color\VkTermColor;
 
 // カラーピッカー使用時のみ
 $vk_term_color = VkTermColor::get_instance();
-$vk_term_color->init( 'text_domain' ); 
+$vk_term_color->initialize( 'text_domain' ); 
 
 
 // 表示用のHTMLを取得する

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -52,6 +52,9 @@ class VkTermColor {
 		if ( class_exists( 'Vk_term_color' ) ) {
 			return;
 		}
+		
+		class_alias( '\VektorInc\VK_Term_Color\VkTermColor', '\Vk_term_color' );
+
 		if ( ! is_null( $textdomain ) ) {
 			$this->textdomain = $textdomain;
 		}
@@ -70,11 +73,6 @@ class VkTermColor {
 			add_filter( 'manage_edit-' . $value . '_columns', array( $this, 'edit_term_columns' ) );
 			add_filter( 'manage_' . $value . '_custom_column', array( $this, 'manage_term_custom_column' ), 10, 3 );
 		}
-
-		if ( ! class_exists( 'Vk_term_color' ) ) {
-			class_alias( '\VektorInc\VK_Term_Color\VkTermColor', '\Vk_term_color' );
-		}
-		
 	}
 
 	/**

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -46,7 +46,7 @@ class VkTermColor {
 	 *
 	 * @return void
 	 */
-	public function init( $textdomain ) {
+	public function set_text_domain( $textdomain ) {
 		$this->textdomain = $textdomain;
 		add_action( 'init', array( $this, 'term_meta_color' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -8,6 +8,7 @@
  * @version 0.4.0
  */
 
+
 namespace VektorInc\VK_Term_Color;
 
 /**
@@ -47,6 +48,10 @@ class VkTermColor {
 	 * @return void
 	 */
 	public function init( $textdomain = null ) {
+
+		if ( class_exists( 'Vk_term_color' ) ) {
+			return;
+		}
 		if ( ! is_null( $textdomain ) ) {
 			$this->textdomain = $textdomain;
 		}
@@ -65,6 +70,11 @@ class VkTermColor {
 			add_filter( 'manage_edit-' . $value . '_columns', array( $this, 'edit_term_columns' ) );
 			add_filter( 'manage_' . $value . '_custom_column', array( $this, 'manage_term_custom_column' ), 10, 3 );
 		}
+
+		if ( ! class_exists( 'Vk_term_color' ) ) {
+			class_alias( '\VektorInc\VK_Term_Color\VkTermColor', '\Vk_term_color' );
+		}
+		
 	}
 
 	/**
@@ -117,7 +127,7 @@ class VkTermColor {
 		$term_color = self::get_term_color( $term->term_id );
 		?>
 			<tr class="form-field">
-			<th scope="row" valign="top"><label for="term_color"><?php esc_html_e( 'Color', $this->textdomain ); ?></label></th>
+			<th scope="row" valign="top"><label for="term_color"><?php esc_html_e( 'Color1', $this->textdomain ); ?></label></th>
 				<td>
 			<?php wp_nonce_field( basename( __FILE__ ), 'term_color_nonce' ); ?>
 					<input type="text" name="term_color" id="term_color" class="term_color" value="<?php echo esc_attr( $term_color ); ?>">

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-term-color
  * @license GPL-2.0+
  *
- * @version 0.4.0
+ * @version 0.5.0
  */
 
 

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -47,7 +47,7 @@ class VkTermColor {
 	 *
 	 * @return void
 	 */
-	public function init( $textdomain = null ) {
+	public function initialize( $textdomain = null ) {
 
 		if ( class_exists( 'Vk_term_color' ) ) {
 			return;

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -46,8 +46,10 @@ class VkTermColor {
 	 *
 	 * @return void
 	 */
-	public function set_text_domain( $textdomain ) {
-		$this->textdomain = $textdomain;
+	public function init( $textdomain = null ) {
+		if ( ! is_null( $textdomain ) ) {
+			$this->textdomain = $textdomain;
+		}
 		add_action( 'init', array( $this, 'term_meta_color' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 


### PR DESCRIPTION
term-colorは vektor-wp-libraryから複製されたものが採用されていて、composer版のものはExUnitでHTML生成時に静的呼び出しとして使われているだけのようでしたので、composer化するために調整をしてみました。
テストはVK Blocksに実装時にVK Blocks側にいれたいと思います。

## 初期化（カラーピッカーを追加する時に実施）
```
use \VektorInc\VK_Term_Color\VkTermColor;
$vk_term_color = VkTermColor::get_instance();
$vk_term_color->initialize( 'vk-blocks' );   // テキストドメインを初期化時に指定する。
```

HTMLなどの取得はこれまでと変わらず、staticな呼び出しでOK


## VK Blocks Proからの呼び出し例  
inc/term-color/term-color-config.php  で以下のように呼び出します。
```
function vk_blocks_load_term_color() {
	$vk_term_color = \VektorInc\VK_Term_Color\VkTermColor::get_instance();
	$vk_term_color->initialize( 'vk-blocks' );
}
add_action( 'init', 'vk_blocks_load_term_color' );
```
## i18n絡みの処理
i18n絡みの処理がライブラリの中にあるとテキストドメインの解決をしなければなりません。
それを上記の方法で解決しています。
ただし、新規プロジェクトでこのライブラリを読み込む時、makepotなどで翻訳を作成する際に、自動的に読み込まれないので、手動で翻訳に取り込む必要はあります。

## vektor-wp-library版との衝突回避について
たとえば、VK Blocks ProにComposer版、Lightningにvektor-wp-library版が入っていた場合、

### vektor-wp-library版が先、composer版が後に呼ばれた場合
vektor-wp-library版が読み込まれます。
しかし、静的呼び出し VkTermColor::get_term_color($term_id); はどちらの版でも問題なく動きます。

### composer版が先、vektor-wp-library版が後に呼ばれた場合
composer版が読み込まれます。
しかし、静的呼び出し Vk_term_color::get_term_color($term_id); はどちらの版でも問題なく動きます。

## 動作確認
手っ取り早いのは composerに入っている VkTermColor.php を当ブランチのコードに一時的に上書きしてください。
ExUnitやLightning/Katawaraの入っている環境で確認ください。

