### PR TITLE
0.6.6 / 存在しないタクソノミーを指定された時に Fatar Error にならないように修正

### DIFF
--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-term-color
  * @license GPL-2.0+
  *
- * @version 0.6.5
+ * @version 0.6.6
  */
 
 namespace VektorInc\VK_Term_Color;
@@ -453,10 +453,10 @@ class VkTermColor {
 		}
 
 		$terms = get_the_terms( $post->ID, $taxonomy );
-		if ( ! $terms ) {
+		if ( is_wp_error( $terms ) || ! $terms) {
 			return;
 		}
-		
+
 		$outer_class = '';
 		if ( ! empty( $args['outer_class'] ) ) {
 			$outer_class = ' class="' . $args['outer_class'] . '"';


### PR DESCRIPTION
```
add_action(
	'lightning_entry_body_before',
	function() {
		$args = array(
			'outer_element'      => 'div',
			'outer_class'        => 'taxonomy_entry_body_before',
			'single_element'     => '',
			'single_class'       => '',
			'single_inner_class' => 'btn btn-sm',
			'link'               => true,
			'color'              => true,
			'taxonomy'           => 'aaa', // ★ここで存在しないタクソノミーを指定されるとエラーになるため
			'gap'                => '0.5rem',
			'separator'          => '',
		);
		echo VkTermColor::get_post_terms_html( '', $args );
	}
);
```