### PR TITLE
【確認待ち】fix: ターム値の保存関数と入力値の受け取りを別関数に切り分け

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,7 @@ npm run phpunit
 
 ## Change log
 
+* save_term_meta_color() を recieve_term_meta_color() に名称変更し、save_term_meta_color()は保存のみを担当するメソッドに変更しました。
+
 0.7.0
 * ブロックなどで使いやすいようにタームの情報を配列で返す get_post_single_term_info() を追加

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -44,8 +44,8 @@ class VkTermColor {
 		foreach ( $taxonomies as $key => $value ) {
 			add_action( $value . '_add_form_fields', array( __CLASS__, 'taxonomy_add_new_meta_field_color' ), 10, 2 );
 			add_action( $value . '_edit_form_fields', array( __CLASS__, 'taxonomy_add_edit_meta_field_color' ), 10, 2 );
-			add_action( 'edited_' . $value, array( __CLASS__, 'save_term_meta_color' ), 10, 2 );
-			add_action( 'create_' . $value, array( __CLASS__, 'save_term_meta_color' ), 10, 2 );
+			add_action( 'edited_' . $value, array( __CLASS__, 'recieve_term_meta_color' ), 10, 2 );
+			add_action( 'create_' . $value, array( __CLASS__, 'recieve_term_meta_color' ), 10, 2 );
 			add_filter( 'manage_edit-' . $value . '_columns', array( __CLASS__, 'edit_term_columns' ) );
 			add_filter( 'manage_' . $value . '_custom_column', array( __CLASS__, 'manage_term_custom_column' ), 10, 3 );
 		}
@@ -117,23 +117,36 @@ class VkTermColor {
 	 * @param int $term_id term id.
 	 * @return void
 	 */
-	public static function save_term_meta_color( $term_id ) {
+	public static function recieve_term_meta_color( $term_id ) {
 
 		if ( ! isset( $_POST['term_color_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['term_color_nonce'] ) ), basename( __FILE__ ) ) ) {
 			return;
 		}
+		$input_color = sanitize_text_field( wp_unslash( $_POST['term_color'] ) );
+		self::save_term_meta_color( $term_id, $input_color );
 
-		if ( isset( $_POST['term_color'] ) ) {
+	}
+
+	/**
+	 * Save color function
+	 * Save extra taxonomy fields callback function.
+	 *
+	 * @param int $term_id term id.
+	 * @return void
+	 */
+	public static function save_term_meta_color( $term_id, $color ) {
+
+		$color = self::sanitize_hex( $color );
+
+		if ( isset( $color ) ) {
 			$now_value = get_term_meta( $term_id, 'term_color', true );
-			$new_value = sanitize_text_field( wp_unslash( $_POST['term_color'] ) );
-			if ( $now_value !== $new_value ) {
-				update_term_meta( $term_id, 'term_color', $new_value );
+			if ( $now_value !== $color ) {
+				update_term_meta( $term_id, 'term_color', $color );
 			} else {
-				add_term_meta( $term_id, 'term_color', $new_value );
+				add_term_meta( $term_id, 'term_color', $color );
 			}
 		}
 	}
-
 	/**
 	 * 管理画面 _ カラーピッカーのスクリプトの読み込み
 	 *
@@ -280,7 +293,7 @@ class VkTermColor {
 		
 					// タームのメタデータから色を取得
 					$color = get_term_meta($term->term_id, 'term_color', true);
-					$color = $color ? $color : $term_color_default;
+					$color = $color ? "#" . $color : $term_color_default;
 
 					// タームのURLを取得
 					$term_url = get_term_link($term);
@@ -578,5 +591,4 @@ class VkTermColor {
 		$taxonomies = array_values( $taxonomies );
 		return $taxonomies;
 	}
-
 }

--- a/tests/test-vk-term-color.php
+++ b/tests/test-vk-term-color.php
@@ -28,7 +28,7 @@ class VkTermColorTest extends WP_UnitTestCase {
             ),
             array(
                 'name' => 'Test Category 1',
-                'color' => '#222222',
+                'color' => '#FFFFFF',
                 'id' => null
             )
         ),
@@ -62,7 +62,7 @@ class VkTermColorTest extends WP_UnitTestCase {
         $this->set_current_user( 'administrator' );
         foreach( $this->test_terms['categories'] as &$category ) {
             $category['id'] = wp_insert_category( array( 'cat_name' => $category['name'] ) );
-            add_term_meta( $category['id'], 'term_color', $category['color'] );
+            VkTermColor::save_term_meta_color($category['id'], $category['color']);
         }
 
         // 各テスト共通タクソノミーの登録
@@ -88,7 +88,7 @@ class VkTermColorTest extends WP_UnitTestCase {
                     array( 'slug' => $term['slug'] )
                 );
                 $term['id'] = $term_id_info['term_id'];
-                add_term_meta( $term['id'], 'term_color', $term['color'] );
+                VkTermColor::save_term_meta_color($term['id'], $term['color']);
             }
         }    
     }
@@ -567,5 +567,4 @@ class VkTermColorTest extends WP_UnitTestCase {
             $this->assertSame( $test['correct'], $return );
         }
     }    
-
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
将来的にVK Blocks ProのSingle Termブロックから直接色変更できる機能をつけることなどを想定すると、ブラウザからの入力値を受け付ける関数と保存する関数は別になっていたほうが今後都合が良いということで分けました。

## どういう変更をしたか？
既存の save_term_meta_color は recieve_term_meta_color に名称変更し、保存部分だけを新たなsave_term_meta_colorに切り出しました。save_term_meta_colorメソッドはフック用なので、外部から呼び出されることはないので名称変更しても良いと判断しました。

テストについては、これまでadd_term_metaでターム値を保存していたのを、新たなsave_term_meta_colorメソッドを利用するように変更したので、従来のテストが通れば保存は正常にできていると判断できます。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
※ 上記「どういう変更をしたか？」参照
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
=> これとは別に２つの修正事項をプルリク予定なので、バージョンは記載せず。
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
レビュワー確認方法と同じ


## 確認URL

ローカル環境

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- 適当なディレクトリに本レポジトリをクローンする。
-  composer install、npm run phpunit を実行
- vk-blocks-pro の開発環境に入れて、ブラウザでひととおり動作確認する。
やりやすい方法で大丈夫です。私は以下のようにしました。
vk-blocks-proのcomposer.jsonの "repositories" と、"require" を以下のように書き換えて、composer.lockを削除し、composer install すると開発中のバージョンが入ります。
```
	"repositories": [
		{
			"type": "composer",
			"url": "https://wpackagist.org"
		},
                {
                    "type": "path",
                    "url": "/(レポジトリまでのパス)/vk-term-color"
                }
	],
	"require": {
		"vektor-inc/vk-term-color": "dev-add/get_post_single_term_info",
	},
```
検証が終わったら変更を破棄して、composer installをやり直す。

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
