### PR TITLE
【確認待ち】 背景色に合わせて動的にテキスト色を決める get_dynamic_text_color() を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,7 @@ npm run phpunit
 
 ## Change log
 
+* 背景色に合わせて 動的にテキスト色を決める get_dynamic_text_color() を追加
+
 0.7.0
 * ブロックなどで使いやすいようにタームの情報を配列で返す get_post_single_term_info() を追加

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -275,11 +275,15 @@ class VkTermColor {
 
 				// タームが存在する場合のみ処理
 				if ($terms && !is_wp_error($terms)) {
+
 					// 最初のタームを使用
 					$term = $terms[0];
 		
 					// タームのメタデータから色を取得
 					$color = self::get_term_color($term->term_id, true);
+					
+					// テキストカラーを自動判定
+					$text_color = self::get_dynamic_text_color($color);
 
 					// タームのURLを取得
 					$term_url = get_term_link($term);
@@ -288,7 +292,8 @@ class VkTermColor {
 					$results = [
 						'term_name' => $term->name,
 						'color' => $color,
-						'term_url' => $term_url
+						'term_url' => $term_url,
+						'text_color' => $text_color
 					];
 		
 					// 一つのタクソノミーのみ処理するため、ループを抜ける
@@ -577,5 +582,30 @@ class VkTermColor {
 		$taxonomies = array_values( $taxonomies );
 		return $taxonomies;
 	}
+
+	/**
+	 * Hex値を受け取りテキスト色を判定する
+	 *
+	 * @param [type] $rgb
+	 * @return void
+	 */
+	public static function get_dynamic_text_color($hex) {
+
+		$hex = str_replace("#", "", $hex);
+	
+		// 3桁の場合は6桁に変換
+		if (strlen($hex) == 3) {
+			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+		}
+	
+		// 16進数からRGB値に変換
+		$r = hexdec(substr($hex, 0, 2));
+		$g = hexdec(substr($hex, 2, 2));
+		$b = hexdec(substr($hex, 4, 2));	
+
+		$yiq = (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+		return $yiq >= 156 ? '#000000' : '#FFFFFF';
+	}
+
 
 }

--- a/src/VkTermColor.php
+++ b/src/VkTermColor.php
@@ -280,7 +280,7 @@ class VkTermColor {
 					$term = $terms[0];
 		
 					// タームのメタデータから色を取得
-					$color = self::get_term_color($term->term_id, true);
+					$color = self::get_term_color($term->term_id);
 					
 					// テキストカラーを自動判定
 					$text_color = self::get_dynamic_text_color($color);

--- a/tests/test-vk-term-color.php
+++ b/tests/test-vk-term-color.php
@@ -23,12 +23,12 @@ class VkTermColorTest extends WP_UnitTestCase {
         'categories' => array(
             array(
                 'name' => 'Test Category 0',
-                'color' => '#111111',
+                'color' => '#FFFFFF',
                 'id' => null
             ),
             array(
                 'name' => 'Test Category 1',
-                'color' => '#222222',
+                'color' => '#cccccc',
                 'id' => null
             )
         ),
@@ -38,13 +38,13 @@ class VkTermColorTest extends WP_UnitTestCase {
                 array(
                     'name' => 'Test Term 0',
                     'slug' => 'test-term-0',
-                    'color' => '#333333',
+                    'color' => '#000000',
                     'id' => null,
                 ),
                 array(
                     'name' => 'Test Term 1',
                     'slug' => 'test-term-1',
-                    'color' => '#333333',
+                    'color' => '#FFFF00',
                     'id' => null,
                 )
             )        
@@ -134,7 +134,8 @@ class VkTermColorTest extends WP_UnitTestCase {
                 'correct' => array(
                     'term_name' =>  $test_category_0['name'],
                     'color' =>  $test_category_0['color'],
-                    'term_url' => site_url() . '/?cat=' .  $test_category_0['id']
+                    'term_url' => site_url() . '/?cat=' .  $test_category_0['id'],
+                    'text_color' => '#000000'
                 )
             ), 
             // カテゴリをセットしない記事は、Uncategorized が返る
@@ -148,7 +149,8 @@ class VkTermColorTest extends WP_UnitTestCase {
                 'correct' => array(
                     'term_name' => 'Uncategorized',
                     'color' => $default_color,
-                    'term_url' => site_url() . '/?cat=1'
+                    'term_url' => site_url() . '/?cat=1',
+                    'text_color' => '#FFFFFF'
                 )
                 ),
             // カテゴリとカスタムタクソノミーをセットした記事で、表示指定をカスタムタクソノミーに指定すると、該当のタクソノミーのタームが返る
@@ -165,7 +167,8 @@ class VkTermColorTest extends WP_UnitTestCase {
                 'correct' => array(
                     'term_name' => $test_term['name'],
                     'color' => $test_term['color'],
-                    'term_url' => site_url() . '/?' . $test_taxonomy_name . '=' .$test_term['slug']
+                    'term_url' => site_url() . '/?' . $test_taxonomy_name . '=' .$test_term['slug'],
+                    'text_color' => '#FFFFFF'
                 )
             ),  
             // カテゴリだけをセットした記事で、表示指定をカスタムタクソノミーに指定すると、取得できず null が返る
@@ -193,7 +196,8 @@ class VkTermColorTest extends WP_UnitTestCase {
                 'correct' => array(
                     'term_name' => 'Uncategorized',
                     'color' => $default_color,
-                    'term_url' => site_url() . '/?cat=1'
+                    'term_url' => site_url() . '/?cat=1',
+                    'text_color' => '#FFFFFF'
                 )
             ),                                      
         );      
@@ -567,5 +571,61 @@ class VkTermColorTest extends WP_UnitTestCase {
             $this->assertSame( $test['correct'], $return );
         }
     }    
+
+    public function test_get_dynamic_text_color() {
+
+        $data = array(
+            '#000000' => '#FFFFFF',
+            '#333333' => '#FFFFFF',
+            '#666666' => '#FFFFFF',
+            '#999999' => '#FFFFFF',
+            '#FFFFFF' => '#000000',
+            '#330000' => '#FFFFFF',
+            '#660000' => '#FFFFFF',
+            '#990000' => '#FFFFFF',
+            '#CC0000' => '#FFFFFF',
+            '#FF0000' => '#FFFFFF',
+            '#003300' => '#FFFFFF',
+            '#006600' => '#FFFFFF',
+            '#009900' => '#FFFFFF',
+            '#00CC00' => '#FFFFFF',
+            '#00FF00' => '#FFFFFF',  
+            '#000033' => '#FFFFFF',
+            '#000066' => '#FFFFFF',
+            '#000099' => '#FFFFFF',
+            '#0000CC' => '#FFFFFF',
+            '#0000FF' => '#FFFFFF',                      
+            '#333300' => '#FFFFFF',
+            '#666600' => '#FFFFFF',
+            '#999900' => '#FFFFFF',
+            '#CCCC00' => '#000000',
+            '#FFFF00' => '#000000',
+            '#003333' => '#FFFFFF',
+            '#006666' => '#FFFFFF',
+            '#009999' => '#FFFFFF',
+            '#00CCCC' => '#FFFFFF',            
+            '#00FFFF' => '#000000',
+            '#330033' => '#FFFFFF',
+            '#660066' => '#FFFFFF',
+            '#990099' => '#FFFFFF',
+            '#CC00CC' => '#FFFFFF',
+            '#FF00FF' => '#FFFFFF',            
+        );
+
+        print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'test_get_dynamic_text_color()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+        foreach ( $data as $input => $correct ) {
+            $return = VkTermColor::get_dynamic_text_color($input);
+            print 'input, correct, return :' . PHP_EOL;
+            var_dump( $input, $correct, $return );
+            print PHP_EOL;       
+            $this->assertSame( $correct, $return );
+        }
+        
+    }
+
 
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
背景色から、上に載せる色を白か黒にするかを判定する get_dynamic_text_color() を追加しました。

なお、しきい値をかなり上げたので、#999999 であれば、色は今まで通り、#FFFFFFを返します。
よほど明るい色のときに、#000000を返すようにしています。

## どういう変更をしたか？
* get_dynamic_text_color() メソッドを追加しました
* get_post_single_term_info() で get_dynamic_text_color()を利用し、text_colorとして返すようにしました。
* get_dynamic_text_color / get_post_single_term_info メソッドのテストを追加・変更

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
※ 上記「どういう変更をしたか？」参照
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
=> これとは別に２つの修正事項をプルリク予定なので、バージョンは記載せず。
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
レビュワー確認方法と同じ


## 確認URL

ローカル環境

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

※ Single Termブロックで利用予定で、まだ未使用のメソッドです。単体テストが通ればOKということになります。

- 適当なディレクトリに本レポジトリをクローンする。
- composer install、npm run phpunit を実行
- コードの目視チェック

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
