### PR TITLE
[ その他 ] GitHub ActionsでDocker Composeエラーを修正

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,8 +16,15 @@ jobs:
       run: composer install
     - name: Install @wordpress/env
       run: npm install -g @wordpress/env
+    - name: Setup Docker Compose
+      run: |
+        # docker-composeコマンドのエイリアスを作成（後方互換性のため）
+        sudo ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose || true
+        # または docker compose を使用するように設定
+        echo 'alias docker-compose="docker compose"' >> ~/.bashrc
+        source ~/.bashrc
     - name: Run @wordpress/env
-      run: npx wp-env start
+      run: npx wp-env@latest start
 
     # PHPUnitテスト実行
     - name: Run PHPUnit test.

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,13 +18,23 @@ jobs:
       run: npm install -g @wordpress/env
     - name: Setup Docker Compose
       run: |
-        # docker-composeコマンドのエイリアスを作成（後方互換性のため）
+        # Docker Composeのバージョンを確認
+        docker compose version
+        # docker-composeコマンドのエイリアスを作成
         sudo ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose || true
-        # または docker compose を使用するように設定
+        # 環境変数でDocker Composeコマンドを設定
+        echo "DOCKER_COMPOSE_CMD=docker compose" >> $GITHUB_ENV
+        # エイリアスを設定
         echo 'alias docker-compose="docker compose"' >> ~/.bashrc
         source ~/.bashrc
+        # エイリアスが正しく設定されているか確認
+        docker-compose --version || docker compose --version
     - name: Run @wordpress/env
-      run: npx wp-env start
+      run: |
+        # Docker Composeの状態を確認
+        docker compose version
+        # wp-envを起動
+        npx wp-env start
 
     # PHPUnitテスト実行
     - name: Run PHPUnit test.

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,7 +24,7 @@ jobs:
         echo 'alias docker-compose="docker compose"' >> ~/.bashrc
         source ~/.bashrc
     - name: Run @wordpress/env
-      run: npx wp-env@latest start
+      run: npx wp-env start
 
     # PHPUnitテスト実行
     - name: Run PHPUnit test.

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,16 +20,22 @@ jobs:
       run: |
         # Docker Composeのバージョンを確認
         docker compose version
-        # docker-composeコマンドのエイリアスを作成
-        sudo ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose || true
         # 環境変数でDocker Composeコマンドを設定
         echo "DOCKER_COMPOSE_CMD=docker compose" >> $GITHUB_ENV
+        echo "COMPOSE_DOCKER_CLI_BUILD=1" >> $GITHUB_ENV
+        echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
+        # docker-composeコマンドのエイリアスを作成
+        sudo ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose || true
         # エイリアスを設定
         echo 'alias docker-compose="docker compose"' >> ~/.bashrc
         source ~/.bashrc
         # エイリアスが正しく設定されているか確認
         docker-compose --version || docker compose --version
     - name: Run @wordpress/env
+      env:
+        DOCKER_COMPOSE_CMD: docker compose
+        COMPOSE_DOCKER_CLI_BUILD: 1
+        DOCKER_BUILDKIT: 1
       run: |
         # Docker Composeの状態を確認
         docker compose version

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,20 +20,14 @@ jobs:
       run: |
         # Docker Composeのバージョンを確認
         docker compose version
-        # docker-composeコマンドのシンボリックリンクを作成
-        sudo ln -sf $(which docker) /usr/local/bin/docker-compose
-        # docker-composeスクリプトを作成
+        # docker-composeスクリプトを作成（無限ループを防ぐため絶対パスを使用）
         sudo tee /usr/local/bin/docker-compose > /dev/null << 'EOF'
         #!/bin/bash
-        docker compose "$@"
+        /usr/bin/docker compose "$@"
         EOF
         sudo chmod +x /usr/local/bin/docker-compose
         # PATHを調整して/usr/local/binを優先
-        echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc
-        source ~/.bashrc
-        # エイリアスを設定
-        echo 'alias docker-compose="docker compose"' >> ~/.bashrc
-        source ~/.bashrc
+        export PATH="/usr/local/bin:$PATH"
         # 確認
         which docker-compose
         docker-compose --version

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,22 +20,24 @@ jobs:
       run: |
         # Docker Composeのバージョンを確認
         docker compose version
-        # 環境変数でDocker Composeコマンドを設定
-        echo "DOCKER_COMPOSE_CMD=docker compose" >> $GITHUB_ENV
-        echo "COMPOSE_DOCKER_CLI_BUILD=1" >> $GITHUB_ENV
-        echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
-        # docker-composeコマンドのエイリアスを作成
-        sudo ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose || true
+        # docker-composeコマンドのシンボリックリンクを作成
+        sudo ln -sf $(which docker) /usr/local/bin/docker-compose
+        # docker-composeスクリプトを作成
+        sudo tee /usr/local/bin/docker-compose > /dev/null << 'EOF'
+        #!/bin/bash
+        docker compose "$@"
+        EOF
+        sudo chmod +x /usr/local/bin/docker-compose
+        # PATHを調整して/usr/local/binを優先
+        echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc
+        source ~/.bashrc
         # エイリアスを設定
         echo 'alias docker-compose="docker compose"' >> ~/.bashrc
         source ~/.bashrc
-        # エイリアスが正しく設定されているか確認
-        docker-compose --version || docker compose --version
+        # 確認
+        which docker-compose
+        docker-compose --version
     - name: Run @wordpress/env
-      env:
-        DOCKER_COMPOSE_CMD: docker compose
-        COMPOSE_DOCKER_CLI_BUILD: 1
-        DOCKER_BUILDKIT: 1
       run: |
         # Docker Composeの状態を確認
         docker compose version


### PR DESCRIPTION
GitHub Actionsで`npx wp-env start`実行時に発生していた`docker-compose ENOENT`エラーを修正しました。

## どういう変更をしたか？

### 原因
- Docker Compose v2で`docker-compose`コマンドが`docker compose`に変更された
- wp-envが内部で`docker-compose`コマンドを直接呼び出していたためエラーが発生

### 修正内容
このやり方でいいのかは少し迷ってます。
ただ、Github ActionsでPHPUnitのためだけに使っていると思うので、このようにしてみました。

- `/usr/local/bin/docker-compose`スクリプトを作成
- スクリプト内で`/usr/bin/docker compose`を呼び出すように設定
- PATHを調整して作成したスクリプトが優先されるように設定

### 確認事項
- [x] GitHub Actionsでwp-envが正常に起動することを確認
- [x] PHPUnitテストが実行可能なことを確認

内部的な修正のためchangelogは書いてません。