### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,10 +1,13 @@
 name: phpunit
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
 
 jobs:
   test:
 
+    if: contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 概要
GitHub Actions の消費削減のため、PHPUnit テストの実行タイミングを見直します。PR は `run-ci` ラベルが付いたときのみ実行するようにします。

## 変更内容
- `.github/workflows/phpunit.yml`
  - `on: pull_request` を展開し `types: [opened, reopened, labeled, synchronize]` を追加
  - `test` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加
  - （元々 push トリガーは無し）

## 確認手順
1. ラベル無しの PR ではワークフローが起動しないこと
2. `run-ci` ラベルを付与すると起動すること
3. push では起動しないこと（元々起動しない）
4. リリース時（該当する場合）は従来どおりであること

CI 設定のみの変更であり、プラグインの動作には影響しません。

関連: vektor-inc/multi-repo-tasks#24
